### PR TITLE
Respect WordPress defined date format

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -291,7 +291,7 @@ function siteorigin_unwind_post_meta() {
 	<?php if ( siteorigin_setting( 'blog_display_date' ) ) { ?>
 		<span class="entry-date">
 			<?php echo ( ! is_singular() ) ? '<a href="' . get_the_permalink() . '" title="' . the_title_attribute( 'echo=0' ) .'">' : ''; ?>
-				<?php the_time( 'M d, Y' ); ?>
+				<?php the_date(); ?>
 			<?php echo ( ! is_singular() ) ? '</a>' : ''; ?>
 		</span>
 	<?php } ?>
@@ -395,7 +395,7 @@ function siteorigin_unwind_related_posts( $post_id ) {
 										<?php the_post_thumbnail( 'siteorigin-unwind-263x174-crop' ); ?>
 									<?php endif; ?>
 									<h3 class="related-post-title"><?php the_title(); ?></h3>
-									<p class="related-post-date"><?php the_time( 'M d, Y' ); ?></p>
+									<p class="related-post-date"><?php the_date(); ?></p>
 								</a>
 							</li>
 						<?php endwhile; ?>

--- a/yarpp-template-unwind.php
+++ b/yarpp-template-unwind.php
@@ -12,7 +12,7 @@ YARPP Template: SiteOrigin Unwind
 						<?php the_post_thumbnail( 'related-post' ); ?>
 					<?php endif; ?>
 					<h3 class="related-post-title"><?php the_title(); ?></h3>
-					<p class="related-post-date"><?php the_time( 'M d, Y' ); ?></p>
+					<p class="related-post-date"><?php the_date(); ?></p>
 				</a>
 			</li>
 		<?php endwhile; ?>


### PR DESCRIPTION
We shouldn't enforce a specific date format and we should instead respect the WordPress defined date format. This is set at WP Admin > Settings > General, and the setting is Date Format.