### PR TITLE
Jetpack Share: Check to ensure sharing_display() exists

### DIFF
--- a/single.php
+++ b/single.php
@@ -25,7 +25,7 @@ get_header(); ?>
 				get_template_part( 'template-parts/content', 'single' );
 			}
 
-			if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'sharedaddy' ) ) : ?>
+			if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'sharedaddy'  )  && function_exists( 'sharing_display' ) ) : ?>
 				<h2 class="share-this heading-strike"><?php esc_html_e( 'Share This', 'siteorigin-unwind' ); ?></h2>
 				<?php echo sharing_display();
 			endif;


### PR DESCRIPTION
This PR adds a function_exists check on sharing_display() as I suspect that function doesn't exist if Jetpack isn't enabled. Plus, [Jetpack recommends doing this](https://jetpack.com/tag/sharedaddy/).

Context:
A user has reported the following error: Fatal error: Call to undefined function sharing_display() in /nas/content/staging/usernamehere/wp-content/themes/siteorigin-unwind/single.php on line 30

I suspect this might be due to them not being able to activate Jetpack at this time (due to mod_auth on WordPress during dev)