### PR TITLE
Header designs

### DIFF
--- a/header.php
+++ b/header.php
@@ -29,72 +29,7 @@
 	<?php if ( siteorigin_page_setting( 'display_masthead', true ) ) : ?>
 		<header id="masthead" class="site-header" role="banner">
 
-			<div class="top-bar <?php if ( siteorigin_setting( 'navigation_sticky' ) ) echo 'sticky-menu'; ?>">
-				<div class="container">
-
-					<div class="social-search">
-						<?php $widget = siteorigin_setting( 'masthead_social_widget' ); ?>
-						<?php if ( ! empty( $widget['networks'] ) && class_exists( 'SiteOrigin_Widget_SocialMediaButtons_Widget' ) ) : ?>
-							<?php the_widget( 'SiteOrigin_Widget_SocialMediaButtons_Widget', $widget ); ?>
-							<span class="v-line"></span>
-						<?php endif; ?>
-						<?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
-							<button id="search-button" class="search-toggle">
-								<span class="open"><?php siteorigin_unwind_display_icon( 'search' ); ?></span>
-								<span class="close"><?php siteorigin_unwind_display_icon( 'close' ); ?></span>
-							</button>
-						<?php endif; ?>
-					</div>
-
-					<nav id="site-navigation" class="main-navigation" role="navigation">
-						<button id="mobile-menu-button" class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php siteorigin_unwind_display_icon( 'menu' ); ?></button>
-						<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
-						<?php if ( class_exists( 'Woocommerce' ) && ! ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_mini_cart' ) ): ?>
-							<?php global $woocommerce; ?>
-							<ul class="shopping-cart">
-								<li>
-									<a class="shopping-cart-link" href="<?php echo $woocommerce->cart->get_cart_url(); ?>">
-										<span class="screen-reader-text"><?php esc_html_e( 'View shopping cart', 'siteorigin-unwind' ); ?></span>
-										<?php siteorigin_unwind_display_icon( 'cart' ); ?>
-										<span class="shopping-cart-text"><?php esc_html_e( ' View Cart ', 'siteorigin-unwind' ); ?></span>
-										<span class="shopping-cart-count"><?php echo WC()->cart->cart_contents_count;?></span>
-									</a>
-									<ul class="shopping-cart-dropdown" id="cart-drop">
-										<?php the_widget( 'WC_Widget_Cart' );?>
-									</ul>
-								</li>
-							</ul>
-						<?php endif; ?>
-					</nav><!-- #site-navigation -->
-					<div id="mobile-navigation"></div>
-
-				</div><!-- .container -->
-
-				<?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
-					<div id="fullscreen-search">
-						<?php get_template_part( 'template-parts/searchform-fullscreen' ); ?>
-					</div>
-				<?php endif; ?>
-			</div><!-- .top-bar -->
-
-
-			<?php if ( ! is_active_sidebar( 'masthead-sidebar' ) ) : ?>
-				<div class="container">
-					<div class="site-branding">
-						<?php siteorigin_unwind_display_logo(); ?>
-						<?php if ( siteorigin_setting( 'branding_site_description' ) ) : ?>
-							<p class="site-description"><?php bloginfo( 'description' ); ?></p>
-						<?php endif ?>
-					</div><!-- .site-branding -->
-				</div><!-- .container -->
-			<?php else : ?>
-				<div id="masthead-widgets" class="container">
-					<?php $siteorigin_unwind_masthead_sidebars = wp_get_sidebars_widgets(); ?>
-					<div class="widgets widgets-<?php echo count( $siteorigin_unwind_masthead_sidebars['masthead-sidebar'] ) ?>" role="complementary" aria-label="<?php esc_html_e( 'Masthead Sidebar', 'siteorigin-unwind' ); ?>">
-						<?php dynamic_sidebar( 'masthead-sidebar' ); ?>
-					</div>				
-				</div><!-- #masthead-widgets -->
-			<?php endif; ?>
+			<?php get_template_part( 'template-parts/header', siteorigin_setting( 'masthead_design' ) ); ?>
 
 		</header><!-- #masthead -->
 	<?php endif; ?>

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -74,12 +74,12 @@ function siteorigin_unwind_body_classes( $classes ) {
 	}
 
 	// If the main sidebar is to be placed on the left
-	if ( siteorigin_setting( 'layout_main_sidebar' ) == 'left' ) {
+	if ( siteorigin_setting( 'layout_main_sidebar' ) == 'left' && is_active_sidebar( 'main-sidebar' ) ) {
 		$classes[] = 'main-sidebar-left';
 	}
 
 	// If the shop sidebar is to be placed on the right
-	if ( siteorigin_setting( 'woocommerce_shop_sidebar' ) == 'right' ) {
+	if ( function_exists( 'is_woocommerce' ) && siteorigin_setting( 'woocommerce_shop_sidebar' ) == 'right' && is_active_sidebar( 'shop-sidebar' ) ) {
 		$classes[] = 'shop-sidebar-right';
 	}
 

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -41,6 +41,10 @@ function siteorigin_unwind_body_classes( $classes ) {
 		$classes[] = 'is_mobile';
 	}
 
+	// Active header template
+
+	$classes[] = 'header-design-' . siteorigin_setting( 'masthead_design' );
+
 	// Add a no-js class which we'll remove as required.
 	$classes[] = 'no-js';
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -112,6 +112,16 @@ function siteorigin_unwind_settings_init() {
 		'masthead' => array(
 			'title' => esc_html__( 'Header', 'siteorigin-unwind' ),
 			'fields' => array(
+				'design'	=> array(
+					'type'	=> 'select',
+					'label'	=> esc_html__( 'Header Design', 'siteorigin-unwind' ),
+					'options' => array(
+						'header-1' => esc_html__( 'Header 1', 'siteorigin-unwind' ),
+						'header-2'  => esc_html__( 'Header 2', 'siteorigin-unwind' ),
+						'header-3' => esc_html__( 'Header 3', 'siteorigin-unwind' ),
+						'header-4'  => esc_html__( 'Header 4', 'siteorigin-unwind' ),
+					),
+				),
 				'social_widget' => array(
 					'type' => 'widget',
 					'widget_class' => 'SiteOrigin_Widget_SocialMediaButtons_Widget',
@@ -1151,6 +1161,7 @@ function siteorigin_unwind_settings_defaults( $defaults ) {
 	$defaults['fonts_text_dark']   = '#2d2d2d';
 
 	// The masthead defaults.
+	$defaults['masthead_design']        = 'header-1';
 	$defaults['masthead_social_widget'] = '';
 	$defaults['masthead_padding']       = '60px';
 	$defaults['masthead_bottom_margin'] = '80px';

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -116,10 +116,10 @@ function siteorigin_unwind_settings_init() {
 					'type'	=> 'select',
 					'label'	=> esc_html__( 'Header Design', 'siteorigin-unwind' ),
 					'options' => array(
-						'header-1' => esc_html__( 'Header 1', 'siteorigin-unwind' ),
-						'header-2'  => esc_html__( 'Header 2', 'siteorigin-unwind' ),
-						'header-3' => esc_html__( 'Header 3', 'siteorigin-unwind' ),
-						'header-4'  => esc_html__( 'Header 4', 'siteorigin-unwind' ),
+						'1' => esc_html__( 'Header 1', 'siteorigin-unwind' ),
+						'2' => esc_html__( 'Header 2', 'siteorigin-unwind' ),
+						'3' => esc_html__( 'Header 3', 'siteorigin-unwind' ),
+						'4' => esc_html__( 'Header 4', 'siteorigin-unwind' ),
 					),
 				),
 				'social_widget' => array(
@@ -1161,7 +1161,7 @@ function siteorigin_unwind_settings_defaults( $defaults ) {
 	$defaults['fonts_text_dark']   = '#2d2d2d';
 
 	// The masthead defaults.
-	$defaults['masthead_design']        = 'header-1';
+	$defaults['masthead_design']        = '1';
 	$defaults['masthead_social_widget'] = '';
 	$defaults['masthead_padding']       = '60px';
 	$defaults['masthead_bottom_margin'] = '80px';

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -193,6 +193,37 @@ function siteorigin_unwind_display_retina_logo( $attr ){
 }
 add_filter( 'siteorigin_unwind_logo_attributes', 'siteorigin_unwind_display_retina_logo', 10, 1 );
 
+if ( ! function_exists( 'siteorigin_unwind_main_navigation' ) ) :
+/**
+ * Display the main menu.
+ */
+function siteorigin_unwind_main_navigation() {
+	?>
+	<nav id="site-navigation" class="main-navigation" role="navigation">
+		<button id="mobile-menu-button" class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php siteorigin_unwind_display_icon( 'menu' ); ?></button>
+		<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
+		<?php if ( class_exists( 'Woocommerce' ) && ! ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_mini_cart' ) ): ?>
+			<?php global $woocommerce; ?>
+			<ul class="shopping-cart">
+				<li>
+					<a class="shopping-cart-link" href="<?php echo $woocommerce->cart->get_cart_url(); ?>">
+						<span class="screen-reader-text"><?php esc_html_e( 'View shopping cart', 'siteorigin-unwind' ); ?></span>
+						<?php siteorigin_unwind_display_icon( 'cart' ); ?>
+						<span class="shopping-cart-text"><?php esc_html_e( ' View Cart ', 'siteorigin-unwind' ); ?></span>
+						<span class="shopping-cart-count"><?php echo WC()->cart->cart_contents_count;?></span>
+					</a>
+					<ul class="shopping-cart-dropdown" id="cart-drop">
+						<?php the_widget( 'WC_Widget_Cart' );?>
+					</ul>
+				</li>
+			</ul>
+		<?php endif; ?>
+	</nav><!-- #site-navigation -->
+	<div id="mobile-navigation"></div>
+	<?php
+}
+endif;
+
 if ( ! function_exists( 'siteorigin_unwind_entry_footer' ) ) :
 /**
  * Prints HTML with meta information for the categories, tags and comments.

--- a/js/unwind.js
+++ b/js/unwind.js
@@ -141,10 +141,10 @@ jQuery( function( $ ) {
 				$tbs = $( '<div class="top-bar-sentinel"></div>' ).insertAfter( $tb );
 			}
 			// Toggle .topbar-out with visibility of top-bar in the viewport
-			if ( $( 'body' ).hasClass( 'sticky-menu' ) && ! $mh.unwindIsVisible() ) {
+			if ( $( 'body' ).hasClass( 'sticky-menu' ) && ! $tbs.unwindIsVisible() ) {
 				$( 'body' ).addClass( 'top-bar-out' );
 			}
-			if ( $( 'body' ).hasClass( 'top-bar-out' ) && $mh.unwindIsVisible() ) {
+			if ( $( 'body' ).hasClass( 'top-bar-out' ) && $tbs.unwindIsVisible() ) {
 				$( 'body' ).removeClass( 'top-bar-out' );
 			}
 		}

--- a/js/unwind.js
+++ b/js/unwind.js
@@ -18,7 +18,6 @@ jQuery( function( $ ) {
 		};
 		resetMenu();
 		$( window ).resize( resetMenu );
-
 	}
 
 	// Check if an element is visible in the viewport
@@ -60,8 +59,10 @@ jQuery( function( $ ) {
 
 		var fullscreenSearch = function() {
 			var vpw = $( window ).width(),
-				vph = $( window ).height();
-			$( '#fullscreen-search' ).css( { 'height': vph - 60 + 'px', 'width': vpw + 'px' } );
+				vph = $( window ).height(),
+				tb = $( '.top-bar' ),
+				tbpos = tb.position().top + tb.outerHeight();
+			$( '#fullscreen-search' ).css( { 'top': tbpos + 'px', 'height': vph - tbpos + 'px', 'width': vpw + 'px' } );
 		};
 		fullscreenSearch();
 		$( window ).resize( fullscreenSearch );

--- a/js/unwind.js
+++ b/js/unwind.js
@@ -21,6 +21,17 @@ jQuery( function( $ ) {
 
 	}
 
+	// Check if an element is visible in the viewport
+	$.fn.unwindIsVisible = function() {
+		var rect = this[0].getBoundingClientRect();
+		return (
+			rect.bottom >= 0 &&
+			rect.right >= 0 &&
+			rect.top <= (window.innerHeight || document.documentElement.clientHeight) &&
+			rect.left <= (window.innerWidth || document.documentElement.clientWidth)
+		);
+	};
+
 	// Featured posts slider.
 	$( document ).ready( function() {
 		if ( $.isFunction( $.fn.flexslider ) ) {
@@ -115,48 +126,31 @@ jQuery( function( $ ) {
 		$( this ).next( 'ul' ).slideToggle( '300ms' );
 	} );
 
-	// Sticky menu.
-	if( $('.top-bar').hasClass('sticky-menu') && !$('body').hasClass('is-mobile') ) {
+	// Sticky menu
+	if ( $( '.top-bar' ).hasClass( 'sticky-menu' ) ) {
 		var $tbs = false,
-			pageTop = $('#page').offset().top,
-			$tb = $('.top-bar');
+			tbTop = false,
+			pageTop = $( '#page' ).offset().top,
+			$tb = $( '.top-bar' ),
+			$mh = $( '#masthead' ),
+			$wpab = $( '#wpadminbar' );
 
-		var smSetup = function () {
-			pageTop = $('#page').offset().top;
+		var smSetup = function() {
 
-			if ($tbs === false) {
-				$tbs = $('<div class="top-bar-sentinel"></div>').insertAfter($tb);
+			if ( $tbs === false ) {
+				$tbs = $( '<div class="top-bar-sentinel"></div>' ).insertAfter( $tb );
 			}
-
-
-			var top  = window.pageYOffset || document.documentElement.scrollTop;
-			$tb.css({
-				'position': 'relative',
-				'top': 0,
-				'left': 0,
-				'width': null,
-			});
-
-			var adminBarOffset = $( '#wpadminbar' ).css('position') === 'fixed' ? $('#wpadminbar').outerHeight() : 0;
-
-			if( $( 'body' ).hasClass( 'woocommerce-demo-store' ) ) {
-				adminBarOffset = $( '.demo_store' ).outerHeight() + $( '.demo_store' ).offset().top - $( document ).scrollTop();
+			// Toggle .topbar-out with visibility of top-bar in the viewport
+			if ( $( 'body' ).hasClass( 'sticky-menu' ) && ! $mh.unwindIsVisible() ) {
+				$( 'body' ).addClass( 'top-bar-out' );
 			}
-
-			$tbs.show().css({
-				'height': $tb.outerHeight(),
-				'margin-bottom' : $tb.css('margin-bottom')
-			});
-			$tb.css({
-				'position': 'fixed',
-				'top': adminBarOffset,
-				'left': 0 - self.pageXOffset+'px',
-				'width': '100%',
-			});
-		};
+			if ( $( 'body' ).hasClass( 'top-bar-out' ) && $mh.unwindIsVisible() ) {
+				$( 'body' ).removeClass( 'top-bar-out' );
+			}
+		}
 		smSetup();
-		$(window).resize( smSetup ).scroll( smSetup );
 
+		$( window ).resize( smSetup ).scroll( smSetup );
 	}
 
 } );

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -119,6 +119,16 @@
 		display: inline-block;
 		float: none;
 	}
+
+	@at-root .header-design-4 & {
+		display: inline-block;
+		float: right;
+		padding: $masthead__padding/2 0;
+
+		> div li a {
+			line-height: 30px;
+		}
+	}
 }
 
 /*--------------------------------------------------------------
@@ -188,17 +198,19 @@
 		width: 1px;
 	}
 
-	@at-root .header-design-3 & {
-		float: none;
+	@at-root {
+		.header-design-3 &,
+		.header-design-4 & {
+			float: none;
 
+			.v-line {
+				display: none;
+			}
 
-		.v-line {
-			display: none;
-		}
-
-		.search-toggle {
-			float: right;
-			line-height: 45px;
+			.search-toggle {
+				float: right;
+				line-height: 45px;
+			}
 		}
 	}
 }
@@ -234,6 +246,10 @@
 	top: 61px;
 	width: 100%;
 	z-index: 10;
+
+	@at-root .header-design-4 & {
+		top: 100px;
+	}
 
 	ul {
 		list-style: none;

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -114,6 +114,11 @@
 			}
 		}
 	}
+
+	@at-root .header-design-3 & {
+		display: inline-block;
+		float: none;
+	}
 }
 
 /*--------------------------------------------------------------
@@ -181,6 +186,20 @@
 		line-height: 60px;
 		margin: 0 8px;
 		width: 1px;
+	}
+
+	@at-root .header-design-3 & {
+		float: none;
+
+
+		.v-line {
+			display: none;
+		}
+
+		.search-toggle {
+			float: right;
+			line-height: 45px;
+		}
 	}
 }
 

--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -49,7 +49,7 @@
 	#masthead-widgets {
 		@include clearfix;
 		margin: 60px auto;
-		
+
 		.widgets {
 
 			@for $i from 1 through 10 {
@@ -75,6 +75,11 @@
 				}
 			}
 		}
+	}
+
+	@at-root .home & {
+		border-bottom: none;
+		margin-bottom: 0;
 	}
 }
 

--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -8,6 +8,11 @@
 		@include clearfix;
 		position: relative;
 		z-index: 9999;
+
+		@at-root .header-design-2 & {
+			border-bottom: none;
+			border-top: 1px solid $color__background-hr-dark;
+		}
 	}
 
 	.top-bar-sentinel {

--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -21,6 +21,8 @@
 			}
 
 			.sticky-menu.top-bar-out & {
+				border-top: none;
+				border-bottom: 1px solid $color__background-hr-dark;
 				position: fixed;
 				top: 0;
 				left: 0;

--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -2,6 +2,10 @@
 	border-bottom: 1px solid $color__background-hr-dark;
 	margin-bottom: $masthead__bottom-margin;
 
+	@at-root .header-design-2 & {
+		border-bottom: none;
+	}
+
 	.top-bar {
 		background: #fff;
 		border-bottom: 1px solid $color__background-hr-dark;
@@ -10,7 +14,6 @@
 		z-index: 9999;
 
 		@at-root .header-design-2 & {
-			border-bottom: none;
 			border-top: 1px solid $color__background-hr-dark;
 		}
 

--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -13,6 +13,34 @@
 			border-bottom: none;
 			border-top: 1px solid $color__background-hr-dark;
 		}
+
+		@at-root {
+			.sticky-menu:not(.top-bar-out) & {
+				position: relative;
+				top: auto;
+			}
+
+			.sticky-menu.top-bar-out & {
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: 100%;
+				@include clearfix;
+			}
+
+			.sticky-menu.top-bar-out.admin-bar & {
+				top: 32px;
+
+				@media screen and (max-width: 782px) {
+					top: 46px;
+				}
+
+				@media screen and (max-width: 600px) {
+					position: absolute;
+					top: auto;
+				}
+			}
+		}
 	}
 
 	.top-bar-sentinel {

--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -17,6 +17,10 @@
 			border-top: 1px solid $color__background-hr-dark;
 		}
 
+		@at-root .home.header-design-2 & {
+			border-bottom: none;
+		}
+
 		@at-root {
 			.sticky-menu:not(.top-bar-out) & {
 				position: relative;

--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -49,6 +49,21 @@
 			margin-bottom: 0;
 			text-align: center;
 		}
+
+		@at-root .header-design-4 & {
+			display: inline-block;
+			padding: $masthead__padding/2 0;
+			text-align: left;
+
+			.site-title {
+				@include font-size(2.5);
+				text-align: left;
+
+				@media (max-width: 480px) {
+					@include font-size(1.8);
+				}
+			}
+		}
 	}
 
 	#masthead-widgets {

--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -86,6 +86,12 @@
 		border-bottom: none;
 		margin-bottom: 0;
 	}
+
+	.main-navigation-bar {
+		border-top: 1px solid $color__background-hr-dark;
+		@include clearfix;
+		text-align: center;
+	}
 }
 
 // Archive and search pages.

--- a/sass/site/header/_search.scss
+++ b/sass/site/header/_search.scss
@@ -2,8 +2,7 @@
 	background: rgba(255, 255, 255, 0.97);
 	display: none;
 	left: 0;
-	position: absolute;
-	top: 61px;
+	position: fixed;
 	z-index: 10;
 
 	.container {

--- a/sass/woocommerce/_cart.scss
+++ b/sass/woocommerce/_cart.scss
@@ -329,6 +329,10 @@
 		padding-left: 0;
 		position: relative;
 
+		@at-root .header-design-4 & {
+			bottom: 0;
+		}
+
 		> li {
 			padding: 0;
 

--- a/style.css
+++ b/style.css
@@ -711,6 +711,12 @@ a {
   .header-design-3 .main-navigation {
     display: inline-block;
     float: none; }
+  .header-design-4 .main-navigation {
+    display: inline-block;
+    float: right;
+    padding: 30px 0; }
+    .header-design-4 .main-navigation > div li a {
+      line-height: 30px; }
 
 /*--------------------------------------------------------------
 ## Social and Search Icons
@@ -754,11 +760,14 @@ a {
     line-height: 60px;
     margin: 0 8px;
     width: 1px; }
-  .header-design-3 .social-search {
+  .header-design-3 .social-search,
+  .header-design-4 .social-search {
     float: none; }
-    .header-design-3 .social-search .v-line {
+    .header-design-3 .social-search .v-line,
+    .header-design-4 .social-search .v-line {
       display: none; }
-    .header-design-3 .social-search .search-toggle {
+    .header-design-3 .social-search .search-toggle,
+    .header-design-4 .social-search .search-toggle {
       float: right;
       line-height: 45px; }
 
@@ -787,6 +796,8 @@ a {
   top: 61px;
   width: 100%;
   z-index: 10; }
+  .header-design-4 #mobile-navigation {
+    top: 100px; }
   #mobile-navigation ul {
     list-style: none;
     margin: 0;
@@ -1491,6 +1502,18 @@ a {
       line-height: 1.7142;
       margin-bottom: 0;
       text-align: center; }
+    .header-design-4 #masthead .site-branding {
+      display: inline-block;
+      padding: 30px 0;
+      text-align: left; }
+      .header-design-4 #masthead .site-branding .site-title {
+        font-size: 40px;
+        font-size: 2.5rem;
+        text-align: left; }
+        @media (max-width: 480px) {
+          .header-design-4 #masthead .site-branding .site-title {
+            font-size: 28.8px;
+            font-size: 1.8rem; } }
   #masthead #masthead-widgets {
     margin: 60px auto; }
     #masthead #masthead-widgets::after {

--- a/style.css
+++ b/style.css
@@ -1515,6 +1515,9 @@ a {
           float: none;
           margin: 0 0 4em;
           width: 100% !important; } }
+  .home #masthead {
+    border-bottom: none;
+    margin-bottom: 0; }
 
 .archive #masthead,
 .search #masthead {

--- a/style.css
+++ b/style.css
@@ -1603,8 +1603,7 @@ a {
   background: rgba(255, 255, 255, 0.97);
   display: none;
   left: 0;
-  position: absolute;
-  top: 61px;
+  position: fixed;
   z-index: 10; }
   #fullscreen-search .container {
     left: 50%;

--- a/style.css
+++ b/style.css
@@ -1450,6 +1450,9 @@ a {
       clear: both;
       content: "";
       display: table; }
+    .header-design-2 #masthead .top-bar {
+      border-bottom: none;
+      border-top: 1px solid #ebebeb; }
   #masthead .top-bar-sentinel {
     box-sizing: border-box; }
   #masthead .site-branding {

--- a/style.css
+++ b/style.css
@@ -708,6 +708,9 @@ a {
     -ms-transform: scaleY(1);
     -o-transform: scaleY(1);
     transform: scaleY(1); }
+  .header-design-3 .main-navigation {
+    display: inline-block;
+    float: none; }
 
 /*--------------------------------------------------------------
 ## Social and Search Icons
@@ -751,6 +754,13 @@ a {
     line-height: 60px;
     margin: 0 8px;
     width: 1px; }
+  .header-design-3 .social-search {
+    float: none; }
+    .header-design-3 .social-search .v-line {
+      display: none; }
+    .header-design-3 .social-search .search-toggle {
+      float: right;
+      line-height: 45px; }
 
 /*--------------------------------------------------------------
 ## Mobile Menu
@@ -1521,6 +1531,13 @@ a {
   .home #masthead {
     border-bottom: none;
     margin-bottom: 0; }
+  #masthead .main-navigation-bar {
+    border-top: 1px solid #ebebeb;
+    text-align: center; }
+    #masthead .main-navigation-bar::after {
+      clear: both;
+      content: "";
+      display: table; }
 
 .archive #masthead,
 .search #masthead {

--- a/style.css
+++ b/style.css
@@ -1462,6 +1462,8 @@ a {
 #masthead {
   border-bottom: 1px solid #ebebeb;
   margin-bottom: 80px; }
+  .header-design-2 #masthead {
+    border-bottom: none; }
   #masthead .top-bar {
     background: #fff;
     border-bottom: 1px solid #ebebeb;
@@ -1472,7 +1474,6 @@ a {
       content: "";
       display: table; }
     .header-design-2 #masthead .top-bar {
-      border-bottom: none;
       border-top: 1px solid #ebebeb; }
     .sticky-menu:not(.top-bar-out) #masthead .top-bar {
       position: relative;

--- a/style.css
+++ b/style.css
@@ -1475,6 +1475,8 @@ a {
       display: table; }
     .header-design-2 #masthead .top-bar {
       border-top: 1px solid #ebebeb; }
+    .home.header-design-2 #masthead .top-bar {
+      border-bottom: none; }
     .sticky-menu:not(.top-bar-out) #masthead .top-bar {
       position: relative;
       top: auto; }

--- a/style.css
+++ b/style.css
@@ -1478,6 +1478,8 @@ a {
       position: relative;
       top: auto; }
     .sticky-menu.top-bar-out #masthead .top-bar {
+      border-top: none;
+      border-bottom: 1px solid #ebebeb;
       position: fixed;
       top: 0;
       left: 0;

--- a/style.css
+++ b/style.css
@@ -1474,6 +1474,27 @@ a {
     .header-design-2 #masthead .top-bar {
       border-bottom: none;
       border-top: 1px solid #ebebeb; }
+    .sticky-menu:not(.top-bar-out) #masthead .top-bar {
+      position: relative;
+      top: auto; }
+    .sticky-menu.top-bar-out #masthead .top-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%; }
+      .sticky-menu.top-bar-out #masthead .top-bar::after {
+        clear: both;
+        content: "";
+        display: table; }
+    .sticky-menu.top-bar-out.admin-bar #masthead .top-bar {
+      top: 32px; }
+      @media screen and (max-width: 782px) {
+        .sticky-menu.top-bar-out.admin-bar #masthead .top-bar {
+          top: 46px; } }
+      @media screen and (max-width: 600px) {
+        .sticky-menu.top-bar-out.admin-bar #masthead .top-bar {
+          position: absolute;
+          top: auto; } }
   #masthead .top-bar-sentinel {
     box-sizing: border-box; }
   #masthead .site-branding {

--- a/template-parts/header-1.php
+++ b/template-parts/header-1.php
@@ -1,0 +1,45 @@
+<div class="top-bar <?php if ( siteorigin_setting( 'navigation_sticky' ) ) echo 'sticky-menu'; ?>">
+    <div class="container">
+
+        <div class="social-search">
+            <?php $widget = siteorigin_setting( 'masthead_social_widget' ); ?>
+            <?php if ( ! empty( $widget['networks'] ) && class_exists( 'SiteOrigin_Widget_SocialMediaButtons_Widget' ) ) : ?>
+                <?php the_widget( 'SiteOrigin_Widget_SocialMediaButtons_Widget', $widget ); ?>
+                <span class="v-line"></span>
+            <?php endif; ?>
+            <?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
+                <button id="search-button" class="search-toggle">
+                    <span class="open"><?php siteorigin_unwind_display_icon( 'search' ); ?></span>
+                    <span class="close"><?php siteorigin_unwind_display_icon( 'close' ); ?></span>
+                </button>
+            <?php endif; ?>
+        </div>
+
+        <?php siteorigin_unwind_main_navigation() ?>
+
+    </div><!-- .container -->
+
+    <?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
+        <div id="fullscreen-search">
+            <?php get_template_part( 'template-parts/searchform-fullscreen' ); ?>
+        </div>
+    <?php endif; ?>
+</div><!-- .top-bar -->
+
+<?php if ( ! is_active_sidebar( 'masthead-sidebar' ) ) : ?>
+    <div class="container">
+        <div class="site-branding">
+            <?php siteorigin_unwind_display_logo(); ?>
+            <?php if ( siteorigin_setting( 'branding_site_description' ) ) : ?>
+                <p class="site-description"><?php bloginfo( 'description' ); ?></p>
+            <?php endif ?>
+        </div><!-- .site-branding -->
+    </div><!-- .container -->
+<?php else : ?>
+    <div id="masthead-widgets" class="container">
+        <?php $siteorigin_unwind_masthead_sidebars = wp_get_sidebars_widgets(); ?>
+        <div class="widgets widgets-<?php echo count( $siteorigin_unwind_masthead_sidebars['masthead-sidebar'] ) ?>" role="complementary" aria-label="<?php esc_html_e( 'Masthead Sidebar', 'siteorigin-unwind' ); ?>">
+            <?php dynamic_sidebar( 'masthead-sidebar' ); ?>
+        </div>
+    </div><!-- #masthead-widgets -->
+<?php endif; ?>

--- a/template-parts/header-2.php
+++ b/template-parts/header-2.php
@@ -1,0 +1,45 @@
+<?php if ( ! is_active_sidebar( 'masthead-sidebar' ) ) : ?>
+    <div class="container">
+        <div class="site-branding">
+            <?php siteorigin_unwind_display_logo(); ?>
+            <?php if ( siteorigin_setting( 'branding_site_description' ) ) : ?>
+                <p class="site-description"><?php bloginfo( 'description' ); ?></p>
+            <?php endif ?>
+        </div><!-- .site-branding -->
+    </div><!-- .container -->
+<?php else : ?>
+    <div id="masthead-widgets" class="container">
+        <?php $siteorigin_unwind_masthead_sidebars = wp_get_sidebars_widgets(); ?>
+        <div class="widgets widgets-<?php echo count( $siteorigin_unwind_masthead_sidebars['masthead-sidebar'] ) ?>" role="complementary" aria-label="<?php esc_html_e( 'Masthead Sidebar', 'siteorigin-unwind' ); ?>">
+            <?php dynamic_sidebar( 'masthead-sidebar' ); ?>
+        </div>
+    </div><!-- #masthead-widgets -->
+<?php endif; ?>
+
+<div class="top-bar <?php if ( siteorigin_setting( 'navigation_sticky' ) ) echo 'sticky-menu'; ?>">
+    <div class="container">
+
+        <div class="social-search">
+            <?php $widget = siteorigin_setting( 'masthead_social_widget' ); ?>
+            <?php if ( ! empty( $widget['networks'] ) && class_exists( 'SiteOrigin_Widget_SocialMediaButtons_Widget' ) ) : ?>
+                <?php the_widget( 'SiteOrigin_Widget_SocialMediaButtons_Widget', $widget ); ?>
+                <span class="v-line"></span>
+            <?php endif; ?>
+            <?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
+                <button id="search-button" class="search-toggle">
+                    <span class="open"><?php siteorigin_unwind_display_icon( 'search' ); ?></span>
+                    <span class="close"><?php siteorigin_unwind_display_icon( 'close' ); ?></span>
+                </button>
+            <?php endif; ?>
+        </div>
+
+        <?php siteorigin_unwind_main_navigation() ?>
+
+    </div><!-- .container -->
+
+    <?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
+        <div id="fullscreen-search">
+            <?php get_template_part( 'template-parts/searchform-fullscreen' ); ?>
+        </div>
+    <?php endif; ?>
+</div><!-- .top-bar -->

--- a/template-parts/header-3.php
+++ b/template-parts/header-3.php
@@ -1,0 +1,49 @@
+<div class="top-bar <?php if ( siteorigin_setting( 'navigation_sticky' ) ) echo 'sticky-menu'; ?>">
+    <div class="container">
+
+        <div class="social-search">
+            <?php $widget = siteorigin_setting( 'masthead_social_widget' ); ?>
+            <?php if ( ! empty( $widget['networks'] ) && class_exists( 'SiteOrigin_Widget_SocialMediaButtons_Widget' ) ) : ?>
+                <?php the_widget( 'SiteOrigin_Widget_SocialMediaButtons_Widget', $widget ); ?>
+                <span class="v-line"></span>
+            <?php endif; ?>
+            <?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
+                <button id="search-button" class="search-toggle">
+                    <span class="open"><?php siteorigin_unwind_display_icon( 'search' ); ?></span>
+                    <span class="close"><?php siteorigin_unwind_display_icon( 'close' ); ?></span>
+                </button>
+            <?php endif; ?>
+        </div>
+
+    </div><!-- .container -->
+
+    <?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
+        <div id="fullscreen-search">
+            <?php get_template_part( 'template-parts/searchform-fullscreen' ); ?>
+        </div>
+    <?php endif; ?>
+</div><!-- .top-bar -->
+
+<?php if ( ! is_active_sidebar( 'masthead-sidebar' ) ) : ?>
+    <div class="container">
+        <div class="site-branding">
+            <?php siteorigin_unwind_display_logo(); ?>
+            <?php if ( siteorigin_setting( 'branding_site_description' ) ) : ?>
+                <p class="site-description"><?php bloginfo( 'description' ); ?></p>
+            <?php endif ?>
+        </div><!-- .site-branding -->
+    </div><!-- .container -->
+<?php else : ?>
+    <div id="masthead-widgets" class="container">
+        <?php $siteorigin_unwind_masthead_sidebars = wp_get_sidebars_widgets(); ?>
+        <div class="widgets widgets-<?php echo count( $siteorigin_unwind_masthead_sidebars['masthead-sidebar'] ) ?>" role="complementary" aria-label="<?php esc_html_e( 'Masthead Sidebar', 'siteorigin-unwind' ); ?>">
+            <?php dynamic_sidebar( 'masthead-sidebar' ); ?>
+        </div>
+    </div><!-- #masthead-widgets -->
+<?php endif; ?>
+
+<div class="main-navigation-bar">
+    <div class="container">
+        <?php siteorigin_unwind_main_navigation() ?>
+    </div>
+</div><!-- .main-navigation-bar -->

--- a/template-parts/header-4.php
+++ b/template-parts/header-4.php
@@ -1,0 +1,35 @@
+<div class="top-bar <?php if ( siteorigin_setting( 'navigation_sticky' ) ) echo 'sticky-menu'; ?>">
+    <div class="container">
+
+        <div class="social-search">
+            <?php $widget = siteorigin_setting( 'masthead_social_widget' ); ?>
+            <?php if ( ! empty( $widget['networks'] ) && class_exists( 'SiteOrigin_Widget_SocialMediaButtons_Widget' ) ) : ?>
+                <?php the_widget( 'SiteOrigin_Widget_SocialMediaButtons_Widget', $widget ); ?>
+                <span class="v-line"></span>
+            <?php endif; ?>
+            <?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
+                <button id="search-button" class="search-toggle">
+                    <span class="open"><?php siteorigin_unwind_display_icon( 'search' ); ?></span>
+                    <span class="close"><?php siteorigin_unwind_display_icon( 'close' ); ?></span>
+                </button>
+            <?php endif; ?>
+        </div>
+
+    </div><!-- .container -->
+
+    <?php if ( siteorigin_setting( 'navigation_search' ) ) : ?>
+        <div id="fullscreen-search">
+            <?php get_template_part( 'template-parts/searchform-fullscreen' ); ?>
+        </div>
+    <?php endif; ?>
+</div><!-- .top-bar -->
+
+<div class="container">
+    <div class="site-branding">
+        <?php siteorigin_unwind_display_logo(); ?>
+        <?php if ( siteorigin_setting( 'branding_site_description' ) ) : ?>
+            <p class="site-description"><?php bloginfo( 'description' ); ?></p>
+        <?php endif ?>
+    </div><!-- .site-branding -->
+    <?php siteorigin_unwind_main_navigation() ?>
+</div><!-- .container -->

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1044,6 +1044,8 @@
   margin: 0;
   padding-left: 0;
   position: relative; }
+  .header-design-4 .main-navigation .shopping-cart {
+    bottom: 0; }
   .main-navigation .shopping-cart > li {
     padding: 0; }
     .main-navigation .shopping-cart > li:hover .shopping-cart-dropdown, .main-navigation .shopping-cart > li.focus .shopping-cart-dropdown {


### PR DESCRIPTION
Theme now has 4 header designs.

1. Added setting to choose header design. ( labeled **Header 1**, **Header 2**, **Header 3** & **Header 4** )
2. Added function `siteorigin_unwind_main_navigation` in `template-tags.php`. ( outputs main navigation )
3. Moved masthead content to the `template-parts` folder. Added files for all 4 designs.
4. Added class to body depending on header design chosen.
5. Reworked sticky navigation.
6. Updated fullscreen search. ( CSS and JS )
7. Removed Masthead bottom border for homepage.
8. _**Unrelated to the rest of this PR** :  Improved logic to sidebar position body classes_

@Misplon please test. Let me know if I have overlooked any issue. This PR is also fixes  #73.