### PR TITLE
Changed the_post_thumbnail() parameters to use traditional array

### DIFF
--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -21,7 +21,7 @@
 
 	<?php if ( has_post_thumbnail() && siteorigin_setting( 'blog_featured_single' ) ) : ?>
 		<div class="entry-thumbnail">
-			<?php the_post_thumbnail( 'post-thumbnail', ['class' => 'aligncenter'] ) ?>
+			<?php the_post_thumbnail( 'post-thumbnail', array( 'class' => 'aligncenter' ) ) ?>
 		</div>
 	<?php endif; ?>
 


### PR DESCRIPTION
Brackets require at least PHP 5.4 so on older setups, this error will occur:

Parse error: syntax error, unexpected ‘[‘ in /home/julianpe/public_html/reachingforless.com/wp-content/themes/siteorigin-unwind/template-parts/content-single.php on line 24