### PR TITLE
Fix uneven logo margin

### DIFF
--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -88,6 +88,10 @@
 			}
 		}
 
+        a, img {
+            display: block;
+        }
+
 		.site-description {
 			@include font-size(0.9333);
 			line-height: 1.7142;


### PR DESCRIPTION
Normal anchor tag and image tag display behavior caused "false" margins below logo images.