### PR TITLE
Higher masthead z-index

### DIFF
--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -1,6 +1,8 @@
 #masthead {
 	border-bottom: 1px solid $color__background-hr-dark;
 	margin-bottom: $masthead__bottom-margin;
+	z-index: 101;
+    	position: relative;
 
 	@at-root .header-design-2 & {
 		border-bottom: none;


### PR DESCRIPTION
non-existent z-index and display: relative; on `#masthead`resulted in sticky header going behind siteorigin hero widget.