### PR TITLE
Comments: Add moderation notice

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -123,6 +123,11 @@ function siteorigin_unwind_comment( $comment, $args, $depth ) {
 				</div>
 
 				<div class="comment-content content">
+					<?php if( ! $comment->comment_approved ) : ?>
+						<p class="comment-awaiting-moderation">
+							<?php _e( 'Your comment is awaiting moderation.', 'siteorigin-unwind' ); ?>
+						</p>
+					<?php endif; ?>
 					<?php comment_text() ?>
 				</div>
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -35,6 +35,9 @@
 
 		.comment-container {
 			margin-left: 6em;
+			.comment-awaiting-moderation {
+				font-style: italic;
+			}
 		}
 
 		&.pingback {

--- a/style.css
+++ b/style.css
@@ -2912,6 +2912,8 @@ a {
         display: table; }
     .comment-list li.comment .comment-container {
       margin-left: 6em; }
+      .comment-list li.comment .comment-container .comment-awaiting-moderation {
+        font-style: italic; }
     .comment-list li.comment.pingback .comment-container {
       margin-left: 0; }
     .comment-list li.comment .avatar-container {


### PR DESCRIPTION
The comment callback in Unwind isn't very clear if your comment is in moderation or not. This PR will correct that.

This is a copy of siteorigin/siteorigin-north#312