### PR TITLE
WC: Add To Cart deprecated notice fix

### DIFF
--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -134,7 +134,13 @@ function siteorigin_unwind_woocommerce_update_cart_count( $fragments ) {
 	return $fragments;
 }
 endif;
-add_filter( 'add_to_cart_fragments', 'siteorigin_unwind_woocommerce_update_cart_count' );
+if( version_compare( $woocommerce->version, '3', '<' ) ) {
+	add_filter( 'add_to_cart_fragments', 'siteorigin_unwind_woocommerce_update_cart_count' );
+} else {
+	add_filter( 'woocommerce_add_to_cart_fragments', 'siteorigin_unwind_woocommerce_update_cart_count' );
+}
+
+
 
 if ( ! function_exists( 'siteorigin_unwind_wc_columns' ) ) :
 // Change number of products per row.


### PR DESCRIPTION
add_to_cart_fragments was deprecated in WC 3 for woocommerce_add_to_cart_fragments. It's just a function rename but this PR will fix it and allow for backwards compatibility.

Copy of siteorigin/siteorigin-north#314