### PR TITLE
Excerpt length

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -296,6 +296,7 @@ add_filter( 'the_content_more_link', 'siteorigin_unwind_read_more_link' );
 if ( ! function_exists( 'siteorigin_unwind_excerpt_length' ) ) :
 /**
  * Filter the excerpt length.
+ * Deprecated.
  */
 function siteorigin_unwind_excerpt_length( $length ) {
 	return siteorigin_setting( 'blog_excerpt_length' );
@@ -306,16 +307,56 @@ endif;
 if ( ! function_exists( 'siteorigin_unwind_excerpt_more' ) ) :
 /**
  * Add a more link to the excerpt.
+ * Deprecated.
  */
 function siteorigin_unwind_excerpt_more( $more ) {
 	if ( is_search() ) return;
 	if ( ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' || siteorigin_setting( 'blog_archive_layout' ) == 'grid' || siteorigin_setting( 'blog_archive_layout' ) == 'alternate' ) && siteorigin_setting( 'blog_excerpt_more', true ) ) {
 		$read_more_text = esc_html__( 'Continue reading now', 'siteorigin-unwind' );
-		return '...<div class="more-link-wrapper"><a class="more-link" href="' . get_permalink() . '"><span class="more-text">' . $read_more_text . '</span></a></div>';
+		return '...<div class="more-link-wrapper"><a class="more-link" href="' . esc_url( get_permalink() ) . '"><span class="more-text">' . $read_more_text . '</span></a></div>';
 	}
 }
 endif;
 add_filter( 'excerpt_more', 'siteorigin_unwind_excerpt_more' );
+
+if ( ! function_exists( 'siteorigin_unwind_excerpt' ) ) :
+/**
+ * Outputs the excerpt.
+ */
+function siteorigin_unwind_excerpt ( $limit, $after ) {
+
+	if ( ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' || siteorigin_setting( 'blog_archive_layout' ) == 'grid' || siteorigin_setting( 'blog_archive_layout' ) == 'alternate' ) && siteorigin_setting( 'blog_excerpt_more', true ) && ! is_search() ) {
+		$read_more_text = esc_html__( 'Continue reading now', 'siteorigin-unwind' );
+		$read_more_text = '...<div class="more-link-wrapper"><a class="more-link" href="' . esc_url( get_permalink() ) . '"><span class="more-text">' . $read_more_text . '</span></a></div>';
+	} else {
+		$read_more_text = '...';
+	}
+	$length = siteorigin_setting( 'blog_excerpt_length' );
+	$excerpt = explode( ' ', get_the_excerpt(), $limit );
+
+	if ( $length ) :
+
+		$excerpt = explode( ' ', get_the_excerpt(), $length );
+
+		if ( count( $excerpt ) >= $length ) :
+			array_pop( $excerpt );
+			$excerpt = implode( " ", $excerpt ). esc_html( $read_more_text );
+		else:
+			$excerpt = implode( " ", $excerpt );
+		endif;
+
+	else :
+
+		$excerpt = get_the_excerpt();
+
+	endif;
+
+	$excerpt = preg_replace( '`\[[^\]]*\]`','', $excerpt );
+
+	echo $excerpt;
+
+}
+endif;
 
 if ( ! function_exists( 'siteorigin_unwind_post_meta' ) ) :
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -323,7 +323,7 @@ if ( ! function_exists( 'siteorigin_unwind_excerpt' ) ) :
 /**
  * Outputs the excerpt.
  */
-function siteorigin_unwind_excerpt ( $limit, $after ) {
+function siteorigin_unwind_excerpt () {
 
 	if ( ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' || siteorigin_setting( 'blog_archive_layout' ) == 'grid' || siteorigin_setting( 'blog_archive_layout' ) == 'alternate' ) && siteorigin_setting( 'blog_excerpt_more', true ) && ! is_search() ) {
 		$read_more_text = esc_html__( 'Continue reading now', 'siteorigin-unwind' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -327,22 +327,21 @@ function siteorigin_unwind_excerpt () {
 
 	if ( ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' || siteorigin_setting( 'blog_archive_layout' ) == 'grid' || siteorigin_setting( 'blog_archive_layout' ) == 'alternate' ) && siteorigin_setting( 'blog_excerpt_more', true ) && ! is_search() ) {
 		$read_more_text = esc_html__( 'Continue reading now', 'siteorigin-unwind' );
-		$read_more_text = '...<div class="more-link-wrapper"><a class="more-link" href="' . esc_url( get_permalink() ) . '"><span class="more-text">' . $read_more_text . '</span></a></div>';
+		$read_more_text = '<div class="more-link-wrapper"><a class="more-link" href="' . esc_url( get_permalink() ) . '"><span class="more-text">' . $read_more_text . '</span></a></div>';
 	} else {
-		$read_more_text = '...';
+		$read_more_text = '';
 	}
+	$ellipsis = '...';
 	$length = siteorigin_setting( 'blog_excerpt_length' );
-	$excerpt = explode( ' ', get_the_excerpt(), $limit );
+	$excerpt = explode( ' ', get_the_excerpt(), $length );
 
 	if ( $length ) :
 
-		$excerpt = explode( ' ', get_the_excerpt(), $length );
-
 		if ( count( $excerpt ) >= $length ) :
 			array_pop( $excerpt );
-			$excerpt = implode( " ", $excerpt ). esc_html( $read_more_text );
+			$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>' . $read_more_text;
 		else:
-			$excerpt = implode( " ", $excerpt );
+			$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>';
 		endif;
 
 	else :

--- a/loops/loop-medium-left.php
+++ b/loops/loop-medium-left.php
@@ -47,7 +47,7 @@ if ( have_posts() ) :
 				</header><!-- .entry-header -->
 
 				<div class="entry-summary">
-					<?php the_excerpt(); ?>
+					<?php siteorigin_unwind_excerpt(); ?>
 				</div><!-- .entry-summary -->
 			</div>
 

--- a/template-parts/content-alternate.php
+++ b/template-parts/content-alternate.php
@@ -54,7 +54,7 @@
 		</header><!-- .entry-header -->
 
 		<?php
-			the_excerpt();
+			siteorigin_unwind_excerpt();
 
 			wp_link_pages( array(
 				'before' => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', 'siteorigin-unwind' ) . '</span>',

--- a/template-parts/content-gallery.php
+++ b/template-parts/content-gallery.php
@@ -52,7 +52,7 @@ $post_class = ( is_singular() ) ? 'entry' : 'archive-entry';
 	<?php endif; ?>
 
 	<div class="entry-content">
-		<?php if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' && $post_class !== 'entry' ) the_excerpt();
+		<?php if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' && $post_class !== 'entry' ) siteorigin_unwind_excerpt();
 		else echo $content; ?>
 		<?php
 			wp_link_pages( array(

--- a/template-parts/content-grid.php
+++ b/template-parts/content-grid.php
@@ -55,7 +55,7 @@
 
 	<div class="entry-content">
 		<?php
-			the_excerpt();
+			siteorigin_unwind_excerpt();
 
 			wp_link_pages( array(
 				'before' => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', 'siteorigin-unwind' ) . '</span>',

--- a/template-parts/content-image.php
+++ b/template-parts/content-image.php
@@ -42,7 +42,7 @@ $post_class = ( is_singular() ) ? 'entry' : 'archive-entry';
 	<?php endif; ?>
 
 	<div class="entry-content">
-		<?php if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' && $post_class !== 'entry' ) the_excerpt();
+		<?php if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' && $post_class !== 'entry' ) siteorigin_unwind_excerpt();
 		else echo apply_filters( 'the_content', siteorigin_unwind_strip_image( get_the_content() ) ); // Display the content without first image ?>
 		<?php
 			wp_link_pages( array(

--- a/template-parts/content-masonry.php
+++ b/template-parts/content-masonry.php
@@ -57,7 +57,7 @@
 
 		<div class="entry-content">
 			<?php
-				the_excerpt();
+				siteorigin_unwind_excerpt();
 
 				wp_link_pages( array(
 					'before' => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', 'siteorigin-unwind' ) . '</span>',

--- a/template-parts/content-offset.php
+++ b/template-parts/content-offset.php
@@ -108,7 +108,7 @@ if ( ! empty( $gallery ) && ! has_action( 'wp_footer', 'siteorigin_unwind_enqueu
 		</div>
 
 		<?php
-			if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' ) the_excerpt();
+			if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' ) siteorigin_unwind_excerpt();
 			else the_content();
 
 			wp_link_pages( array(

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -38,7 +38,7 @@ $post_class = siteorigin_setting( 'blog_search_fallback' ) ? 'has-fallback-image
 		</header><!-- .entry-header -->
 
 		<div class="entry-summary">
-			<?php the_excerpt(); ?>
+			<?php siteorigin_unwind_excerpt(); ?>
 		</div><!-- .entry-summary -->
 	</div>
 

--- a/template-parts/content-video.php
+++ b/template-parts/content-video.php
@@ -42,7 +42,7 @@ $post_class = ( is_singular() ) ? 'entry' : 'archive-entry';
 	<?php endif; ?>
 
 	<div class="entry-content">
-		<?php if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' && $post_class !== 'entry' ) the_excerpt();
+		<?php if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' && $post_class !== 'entry' ) siteorigin_unwind_excerpt();
 		else echo apply_filters( 'the_content', siteorigin_unwind_filter_video( get_the_content() ) ); // Display the content without first video ?>
 		<?php
 			wp_link_pages( array(

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -32,7 +32,7 @@
 
 	<div class="entry-content">
 		<?php
-			if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' ) the_excerpt();
+			if ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' ) siteorigin_unwind_excerpt();
 			else the_content();
 
 			wp_link_pages( array(


### PR DESCRIPTION
Fixed bug #207 

The `excerpt_length` and `excerpt_more` filters only work on excerpts that are generated from the content.

Added `siteorigin_unwind_excerpt` function to handle all excerpts. Should be used instead of `the_excerpt`.

Deprecated functions `siteorigin_unwind_excerpt_length` and `siteorigin_unwind_excerpt_more`.

Please test. Thanks. 