### PR TITLE
Mobile Menu: Update aria-expanded state, allow for # links to open sub menu

### DIFF
--- a/js/unwind.js
+++ b/js/unwind.js
@@ -124,12 +124,24 @@ jQuery( function( $ ) {
 	$( '#mobile-navigation' ).on( 'click', '.dropdown-toggle', function( e ) {
 		e.preventDefault();
 		$( this ).next( 'ul' ).slideToggle( '300ms' );
+		
+		if( $( this ).attr( 'aria-expanded' ) == 'false' ) {
+			$( this ).attr( 'aria-expanded', 'true' )
+		} else {
+			$( this ).attr( 'aria-expanded', 'false' )
+		}
 	} );
 
 	$( '#mobile-navigation' ).on( 'click', '.has-dropdown-button', function( e ) {
-		if ( typeof $( this ).attr( 'href' ) === "undefined" ) {
+		if ( typeof $( this ).attr( 'href' ) === "undefined" || $( this ).attr( 'href' ) == "#" ) {
 			e.preventDefault();
 			$( this ).siblings( 'ul' ).slideToggle( '300ms' );
+
+			if( $( this ).siblings( '.dropdown-toggle' ).attr( 'aria-expanded' ) == 'false' ) {
+				$( this ).siblings( '.dropdown-toggle' ).attr( 'aria-expanded', 'true' )
+			} else {
+				$( this ).siblings( '.dropdown-toggle' ).attr( 'aria-expanded', 'false' )
+			}
 		}
 	} );
 


### PR DESCRIPTION
It's great that aria-expanded is present, but it doesn't currently change regardless of state. This PR fixes that. It also allows for # links to correctly open sub menus.