### PR TITLE
Social icons alignment fix for certain header designs

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -215,13 +215,20 @@
 		.header-design-4 & {
 			float: none;
 
+			.widget_sow-social-media-buttons {
+				width: 100%;
+			}
+
 			.v-line {
 				display: none;
 			}
 
 			.search-toggle {
-				float: right;
+				float: none;
 				line-height: 45px;
+				position: absolute;
+				top: 0;
+				right: 0;
 			}
 		}
 	}

--- a/style.css
+++ b/style.css
@@ -752,13 +752,19 @@ a {
   .header-design-3 .social-search,
   .header-design-4 .social-search {
     float: none; }
+    .header-design-3 .social-search .widget_sow-social-media-buttons,
+    .header-design-4 .social-search .widget_sow-social-media-buttons {
+      width: 100%; }
     .header-design-3 .social-search .v-line,
     .header-design-4 .social-search .v-line {
       display: none; }
     .header-design-3 .social-search .search-toggle,
     .header-design-4 .social-search .search-toggle {
-      float: right;
-      line-height: 45px; }
+      float: none;
+      line-height: 45px;
+      position: absolute;
+      top: 0;
+      right: 0; }
 
 /*--------------------------------------------------------------
 ## Mobile Menu


### PR DESCRIPTION
Previously, the Social Icons alignment setting wouldn't do anything. This is okay for the header designs where this everything is on the same line but when the social icons are on a different line to the menu, the alignment options really need to work.

![](https://i.imgur.com/cZOfj08.png)
