### PR TITLE
Account for missing Custom Icon

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -620,7 +620,7 @@ function siteorigin_unwind_display_icon( $type ) {
 	switch( $type ) {
 
 		case 'fullscreen-search' :
-			if ( siteorigin_setting( 'icons_fullscreen_search' ) ) : ?>
+			if ( siteorigin_setting( 'icons_fullscreen_search' ) && wp_attachment_is_image( siteorigin_setting( 'icons_fullscreen_search' ) ) ) : ?>
 				<?php siteorigin_unwind_custom_icon( 'icons_fullscreen_search', 'svg-icon-fullscreen-search' ); ?>
 			<?php else : ?>
 				<svg version="1.1" class="svg-icon-fullscreen-search" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 32 32">
@@ -638,7 +638,7 @@ function siteorigin_unwind_display_icon( $type ) {
 				break;
 
 		case 'search' :
-			if ( siteorigin_setting( 'icons_search' ) ): ?>
+			if ( siteorigin_setting( 'icons_search' ) && wp_attachment_is_image( siteorigin_setting( 'icons_search' ) ) ): ?>
 				<?php siteorigin_unwind_custom_icon( 'icons_search', 'svg-icon-search' ); ?>
 			<?php else : ?>
 				<svg version="1.1" class="svg-icon-search" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 32 32">
@@ -648,7 +648,7 @@ function siteorigin_unwind_display_icon( $type ) {
 			break;
 
 		case 'close' :
-			if ( siteorigin_setting( 'icons_close_search' ) ): ?>
+			if ( siteorigin_setting( 'icons_close_search' ) && wp_attachment_is_image( siteorigin_setting( 'icons_close_search' ) ) ): ?>
 				<?php siteorigin_unwind_custom_icon( 'icons_close_search', 'svg-icon-close' ); ?>
 			<?php else : ?>
 				<svg version="1.1" class="svg-icon-close" xmlns="http://www.w3.org/2000/svg" width="15.56" height="15.562" viewBox="0 0 15.56 15.562">
@@ -658,7 +658,7 @@ function siteorigin_unwind_display_icon( $type ) {
 			break;
 
 		case 'menu':
-			if ( siteorigin_setting( 'icons_menu' ) ): ?>
+			if ( siteorigin_setting( 'icons_menu' ) && wp_attachment_is_image( siteorigin_setting( 'icons_menu' ) ) ): ?>
 				<?php siteorigin_unwind_custom_icon( 'icons_menu', 'svg-icon-menu' ); ?>
 			<?php else : ?>
 				<svg version="1.1" class="svg-icon-menu" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="27" height="32" viewBox="0 0 27 32">


### PR DESCRIPTION
A user reported an issue with their mobile menu not working in Unwind. Turns out they have previously set a custom mobile menu icon and forgot about it. They then accidentally deleted the mobile menu icon and when this happens, the mobile menu icon doesn't display. This PR accounts for this situation by ensuring the image exists and is actually an image.