### PR TITLE
Search Forms: Replace all instances of site_url() with home_url()

### DIFF
--- a/template-parts/searchform-fullscreen.php
+++ b/template-parts/searchform-fullscreen.php
@@ -13,7 +13,7 @@
 
 <div class="container">
 	<h3><?php esc_html_e( 'Search Site', 'siteorigin-unwind' ); ?></h3>
-	<form id="fullscreen-search-form" method="get" action="<?php echo esc_url( site_url() ) ?>">
+	<form id="fullscreen-search-form" method="get" action="<?php echo esc_url( home_url() ) ?>">
 		<input type="search" name="s" placeholder="<?php esc_attr_e( 'Type and hit enter to search', 'siteorigin-unwind') ?>" value="<?php echo get_search_query() ?>" />
 		<button type="submit">
 			<label class="screen-reader-text"><?php esc_html_e( 'Search', 'siteorigin-unwind' ); ?></label>

--- a/woocommerce/product-searchform.php
+++ b/woocommerce/product-searchform.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 
-<form role="search" method="get" class="search-form" action="<?php echo esc_url( site_url() ) ?>">
+<form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url() ) ?>">
 	<label for='s' class='screen-reader-text'><?php esc_html_e( 'Search for:', 'siteorigin-unwind' ); ?></label>
 	<input type="search" id="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>" class="search-field" placeholder="<?php echo esc_attr__( 'Search products&hellip;', 'siteorigin-unwind' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
 	<button type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'siteorigin-unwind' ); ?>">


### PR DESCRIPTION
This PR replaces site_url() with home_url(). The Site URL can be different to the Home URL as a result of how the user structures their website files. For example, if the user has their files in a separate directory to the root of the domain, the Site URL will be different to the Home URL.

References:
https://github.com/woocommerce/woocommerce/blob/master/templates/product-searchform.php
https://github.com/WordPress/WordPress/blob/master/wp-content/themes/twentyseventeen/searchform.php#L15