### PR TITLE
Woo variation swatches

### DIFF
--- a/js/woocommerce.js
+++ b/js/woocommerce.js
@@ -172,7 +172,7 @@ jQuery( function( $ ) {
 			}
 		} );
 
-	} );	
+	} );
 
 	$( so_unwind_data.chevron_down ).insertAfter( '.variations select' );
 

--- a/js/woocommerce.js
+++ b/js/woocommerce.js
@@ -174,6 +174,8 @@ jQuery( function( $ ) {
 
 	} );
 
-	$( so_unwind_data.chevron_down ).insertAfter( '.variations select' );
+	if ( ! $( 'body' ).hasClass( 'woo-variation-swatches' ) ) {
+		$( so_unwind_data.chevron_down ).insertAfter( '.variations select' );
+	}
 
 } );

--- a/sass/woocommerce/_product.scss
+++ b/sass/woocommerce/_product.scss
@@ -96,9 +96,25 @@
 
 					tr {
 						background: none;
+						
+						&:last-of-type {
+
+							td {
+								padding: 0;
+							}
+						}
 					}
 
 					td {
+						padding: 0;
+					}
+
+					// Woo Variation Swatches plugin.
+					@at-root .woo-variation-swatches.woocommerce.single-product #content div.product .entry-summary .cart .variations td {
+						padding: 0 0 10px;
+					}
+
+					@at-root .woo-variation-swatches.woocommerce.single-product #content div.product .entry-summary .cart .variations tr:last-of-type td {
 						padding: 0;
 					}
 				}

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -540,7 +540,13 @@ p.demo_store {
       font-family: "Merriweather", serif; }
       .woocommerce.single-product #content div.product .entry-summary .cart .variations tr {
         background: none; }
+        .woocommerce.single-product #content div.product .entry-summary .cart .variations tr:last-of-type td {
+          padding: 0; }
       .woocommerce.single-product #content div.product .entry-summary .cart .variations td {
+        padding: 0; }
+      .woo-variation-swatches.woocommerce.single-product #content div.product .entry-summary .cart .variations td {
+        padding: 0 0 10px; }
+      .woo-variation-swatches.woocommerce.single-product #content div.product .entry-summary .cart .variations tr:last-of-type td {
         padding: 0; }
     .woocommerce.single-product #content div.product .entry-summary .cart .woocommerce-variation-price {
       margin-bottom: 20px; }

--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -35,7 +35,6 @@ function siteorigin_unwind_woocommerce_setup() {
 		add_theme_support( 'wc-product-gallery-zoom' );
 	}
 
-
 }
 add_action( 'after_setup_theme', 'siteorigin_unwind_woocommerce_setup' );
 
@@ -57,7 +56,7 @@ function siteorigin_unwind_woocommerce_enqueue_styles( $styles ) {
 add_filter( 'woocommerce_enqueue_styles', 'siteorigin_unwind_woocommerce_enqueue_styles' );
 
 function siteorigin_unwind_woocommerce_enqueue_scripts() {
-	
+
 	wp_enqueue_script( 'siteorigin-unwind-woocommerce', get_template_directory_uri() . '/js/woocommerce.js', array( 'jquery', 'wc-add-to-cart-variation' ), SITEORIGIN_THEME_VERSION );
 
 	$script_data = array(
@@ -93,11 +92,11 @@ add_filter( 'loop_shop_columns', 'siteorigin_unwind_woocommerce_loop_shop_column
  * @link https://github.com/woocommerce/woocommerce/wiki/Customizing-image-sizes-in-3.3-
  */
 function siteorigin_unwind_woocommerce_single_gallery_thumbnail_size( $size ) {
-    return array(
-        'width'  => 150,
-        'height' => 150,
-        'crop'   => 1,
-    );	
+	return array(
+		'width'  => 150,
+		'height' => 150,
+		'crop'   => 1,
+	);
 }
 add_filter( 'woocommerce_get_image_size_gallery_thumbnail', 'siteorigin_unwind_woocommerce_single_gallery_thumbnail_size' );
 


### PR DESCRIPTION
@AlexGStapleton Using develop, activate https://wordpress.org/plugins/woo-variation-swatches/ and check a product with variations. Check the formatting issues. Then switch to this branch. 

If there is a better way to make the exclusion in the JS file or anything else you see, please, let me know.