### PR TITLE
WooCommerce Product Overlay Improvements

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -77,13 +77,20 @@ function siteorigin_unwind_body_classes( $classes ) {
 	}
 
 	// WooCommerce columns.
-	if ( siteorigin_setting( 'woocommerce_archive_columns' ) ) {
+	if ( function_exists( 'is_woocommerce' ) && ( is_woocommerce() || wc_post_content_has_shortcode( 'products' ) ) ) {
 		$classes[] = 'wc-columns-' . siteorigin_setting( 'woocommerce_archive_columns' );
 	}
 
-	// WooCommerce Add to Cart.
-	if ( function_exists( 'is_woocommerce' ) && siteorigin_setting( 'woocommerce_add_to_cart' ) ) {
-		$classes[] = 'unwind-add-to-cart';
+	// WooCommerce archive Quick View and Add to Cart.
+	if ( function_exists( 'is_woocommerce' ) && ( is_woocommerce() || is_cart() || wc_post_content_has_shortcode( 'products' ) ) ) {
+		if ( siteorigin_setting( 'woocommerce_display_quick_view' ) || siteorigin_setting( 'woocommerce_add_to_cart' ) ) {
+			$classes[] = 'unwind-product-overlay';
+		}
+
+		if ( siteorigin_setting( 'woocommerce_display_quick_view' ) && ! siteorigin_setting( 'woocommerce_add_to_cart' )
+			|| ! siteorigin_setting( 'woocommerce_display_quick_view' ) && siteorigin_setting( 'woocommerce_add_to_cart' ) ) {
+			$classes[] = 'unwind-product-overlay-single';
+		}
 	}
 
 	return $classes;

--- a/sass/woocommerce/_archive.scss
+++ b/sass/woocommerce/_archive.scss
@@ -217,11 +217,11 @@
 				background: $color__primary-accent-dark;
 				position: relative;
 
-				@at-root .unwind-add-to-cart ul.products li.product .loop-product-thumbnail:hover img {
+				@at-root .unwind-product-overlay ul.products li.product .loop-product-thumbnail:hover img {
 					opacity: 0.25;
 				}
 
-				@at-root .unwind-add-to-cart.is_mobile ul.products li.product .loop-product-thumbnail:hover img {
+				@at-root .unwind-product-overlay.is_mobile ul.products li.product .loop-product-thumbnail:hover img {
 					opacity: 1;
 					visibility: visible;
 				}

--- a/sass/woocommerce/_archive.scss
+++ b/sass/woocommerce/_archive.scss
@@ -337,9 +337,7 @@
 					}
 				}
 
-				// Checking for two items within .loop-product-thumbnail.
-				a:first-child:nth-last-child(2),
-				a:first-child:nth-last-child(2) ~ a {
+				@at-root .unwind-product-overlay-single ul.products li.product .loop-product-thumbnail a:nth-of-type(2) {
 					bottom: auto;
 					top: 50%;
 					transform: translate(-50%, -50%);

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -343,9 +343,9 @@ p.demo_store {
   .woocommerce ul.products li.product .loop-product-thumbnail {
     background: #00a76a;
     position: relative; }
-    .unwind-add-to-cart.woocommerce ul.products li.product .loop-product-thumbnail:hover img {
+    .unwind-product-overlay ul.products li.product .loop-product-thumbnail:hover img {
       opacity: 0.25; }
-    .unwind-add-to-cart.is_mobile.woocommerce ul.products li.product .loop-product-thumbnail:hover img {
+    .unwind-product-overlay.is_mobile ul.products li.product .loop-product-thumbnail:hover img {
       opacity: 1;
       visibility: visible; }
     .woocommerce ul.products li.product .loop-product-thumbnail:hover .add_to_cart_button,

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -440,6 +440,10 @@ p.demo_store {
       .woocommerce ul.products li.product .loop-product-thumbnail a.added_to_cart:hover {
         border: 2px solid #2d2d2d;
         border-bottom: 0; }
+    .unwind-product-overlay-single ul.products li.product .loop-product-thumbnail a:nth-of-type(2) {
+      bottom: auto;
+      top: 50%;
+      transform: translate(-50%, -50%); }
 
 .woocommerce .woocommerce-pagination .page-numbers {
   border: none; }

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -184,14 +184,14 @@ p.demo_store {
   .woocommerce .woocommerce-ordering .ordering-selector-wrapper {
     border: 1px solid #ebebeb;
     box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
     color: #626262;
     display: block;
     font-size: 0.85em;
     line-height: 1em;
     padding: 10px;
-    position: relative;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box; }
+    position: relative; }
     .woocommerce .woocommerce-ordering .ordering-selector-wrapper .current {
       display: inline-block; }
     .woocommerce .woocommerce-ordering .ordering-selector-wrapper svg {
@@ -253,12 +253,12 @@ p.demo_store {
           color: #2d2d2d; }
     .woocommerce .woocommerce-ordering .ordering-selector-wrapper.open-dropdown .ordering-dropdown {
       opacity: 1;
-      visibility: visible;
       -webkit-transform: scale(1);
       -moz-transform: scale(1);
       -ms-transform: scale(1);
       -o-transform: scale(1);
-      transform: scale(1); }
+      transform: scale(1);
+      visibility: visible; }
     .woocommerce .woocommerce-ordering .ordering-selector-wrapper.open-dropdown svg {
       -webkit-transform: rotate(0deg);
       -moz-transform: rotate(0deg);
@@ -316,10 +316,10 @@ p.demo_store {
     font-size: 12px;
     font-weight: normal;
     left: 0;
-    right: auto;
     line-height: normal;
     min-height: 0;
     padding: 6px 12px;
+    right: auto;
     text-transform: uppercase;
     top: 6px;
     z-index: 10; }

--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -57,7 +57,9 @@ add_filter( 'woocommerce_enqueue_styles', 'siteorigin_unwind_woocommerce_enqueue
 
 function siteorigin_unwind_woocommerce_enqueue_scripts() {
 
+	if ( is_woocommerce() || is_cart() || wc_post_content_has_shortcode( 'products' ) ) {
 	wp_enqueue_script( 'siteorigin-unwind-woocommerce', get_template_directory_uri() . '/js/woocommerce' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery', 'wc-add-to-cart-variation' ), SITEORIGIN_THEME_VERSION );
+	}
 
 	$script_data = array(
 		'chevron_down' => '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="10" height="10" viewBox="0 0 32 32"><path d="M30.054 14.429l-13.25 13.232q-0.339 0.339-0.804 0.339t-0.804-0.339l-13.25-13.232q-0.339-0.339-0.339-0.813t0.339-0.813l2.964-2.946q0.339-0.339 0.804-0.339t0.804 0.339l9.482 9.482 9.482-9.482q0.339-0.339 0.804-0.339t0.804 0.339l2.964 2.946q0.339 0.339 0.339 0.813t-0.339 0.813z"></path></svg>',

--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -58,7 +58,7 @@ add_filter( 'woocommerce_enqueue_styles', 'siteorigin_unwind_woocommerce_enqueue
 function siteorigin_unwind_woocommerce_enqueue_scripts() {
 
 	if ( is_woocommerce() || is_cart() || wc_post_content_has_shortcode( 'products' ) ) {
-	wp_enqueue_script( 'siteorigin-unwind-woocommerce', get_template_directory_uri() . '/js/woocommerce' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery', 'wc-add-to-cart-variation' ), SITEORIGIN_THEME_VERSION );
+		wp_enqueue_script( 'siteorigin-unwind-woocommerce', get_template_directory_uri() . '/js/woocommerce' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery', 'wc-add-to-cart-variation' ), SITEORIGIN_THEME_VERSION );
 	}
 
 	$script_data = array(


### PR DESCRIPTION
This should have been split up into smaller PR's, please, bear with me. Sorry for the hassle.

**Conditionally load the WooCommerce JavaScript file:**
* If we’re on a known WooCommerce page.
* If we're on the cart page.
* If the page has a product shortcode.

**Added an overlay class in place of the add to cart class**
This is to ensure the green overlay is added for WooCommerce archive pages and WooCommerce product shortcodes if both or one of the buttons is present, Add to Cart and or Quick View.

**Reorder selectors**
This commit made it was into the PR accidentally.

**Added class for when one button is present**
The goal here is to vertically center the Add to Cart or Quick View button if it's the only button present. The method we're using in Corp `a:first-child:nth-last-child(2) ~ a` doesn't work because once you click the Add to Cart button, the Added to Cart button appears, disrupting the count and thereby throwing off the alignment.