### PR TITLE
Account for Post Loop being used on static front page

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -478,9 +478,20 @@ if ( ! function_exists( 'siteorigin_unwind_posts_navigation' ) ) :
  *
  */
 function siteorigin_unwind_posts_navigation() {
+	global $paged;
+
 	// Don't print empty markup if there's only one page.
 	if ( $GLOBALS['wp_query']->max_num_pages < 2 ) {
 		return;
+	}
+
+	// Account for the a post loop widget being used on the front page
+	if ( get_query_var( 'paged' ) ) {
+	$paged = get_query_var( 'paged' );
+	} elseif ( get_query_var( 'page' ) ) {
+		$paged = get_query_var( 'page' );
+	} else {
+		$paged = 1;
 	}
 	?>
 	<nav class="navigation posts-navigation" role="navigation">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -485,7 +485,7 @@ function siteorigin_unwind_posts_navigation() {
 		return;
 	}
 
-	// Account for the a post loop widget being used on the front page
+	// Account for the a Post Loop widget being used on the front page.
 	if ( get_query_var( 'paged' ) ) {
 	$paged = get_query_var( 'paged' );
 	} elseif ( get_query_var( 'page' ) ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-unwind/issues/289

The static front page doesn't set the paged query var, instead it uses page. `previous/next_posts_link` doesn't check if `page` is set and only checks for `paged`.

This isn't an issue with our themes due to those all using `paginate_links)`. This also isn't an issue with the post loop itself, not the pagination, as it accounts for this - try manually changing the page URL and you'll notice the posts change as expected.