### PR TITLE
Set WC JS to load in footer to prevent spacing issue

### DIFF
--- a/sass/woocommerce/_product.scss
+++ b/sass/woocommerce/_product.scss
@@ -212,10 +212,6 @@
 
 		.images {
 
-			.flex-viewport {
-				height: auto !important;
-			}
-
 			.flex-control-nav {
 				margin-top: 10px;
 

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -618,9 +618,6 @@ p.demo_store {
       color: #2d2d2d;
       display: inline-block; }
 
-.woocommerce.single-product #content div.product .images .flex-viewport {
-  height: auto !important; }
-
 .woocommerce.single-product #content div.product .images .flex-control-nav {
   margin-top: 10px; }
   .woocommerce.single-product #content div.product .images .flex-control-nav li img {

--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -58,7 +58,7 @@ add_filter( 'woocommerce_enqueue_styles', 'siteorigin_unwind_woocommerce_enqueue
 function siteorigin_unwind_woocommerce_enqueue_scripts() {
 
 	if ( is_woocommerce() || is_cart() || wc_post_content_has_shortcode( 'products' ) ) {
-		wp_enqueue_script( 'siteorigin-unwind-woocommerce', get_template_directory_uri() . '/js/woocommerce' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery', 'wc-add-to-cart-variation' ), SITEORIGIN_THEME_VERSION );
+		wp_enqueue_script( 'siteorigin-unwind-woocommerce', get_template_directory_uri() . '/js/woocommerce' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery', 'wc-add-to-cart-variation' ), SITEORIGIN_THEME_VERSION, true );
 	}
 
 	$script_data = array(


### PR DESCRIPTION
This PR reverts commit 372f37e18a8ea09ede8a500c4bb3c172d646de1c which was to resolve https://github.com/siteorigin/siteorigin-unwind/issues/274. The problem is that change resulted in the gallery area height being based on the largest image. Depending on the user's images this can sometimes result in a large amount of spacing. For example:

![Screenshot_2020-11-05 Lumot artwork on Society6 – Lumot (1)](https://user-images.githubusercontent.com/17275120/98464376-36404400-220e-11eb-892a-2c945b50a700.png)

The last commit resolves the original issue by moving the WC JS file to the footer.
