### PR TITLE
Don’t size the featured image unless the default page layout is in use

### DIFF
--- a/template-parts/content-alternate.php
+++ b/template-parts/content-alternate.php
@@ -33,7 +33,11 @@
 				</div>
 			<?php elseif ( has_post_thumbnail() ) : ?>
 				<a href="<?php the_permalink() ?>">
-					<?php the_post_thumbnail( 'siteorigin-unwind-360x238-crop', array( 'class' => 'aligncenter' ) ); ?>
+					<?php if ( ! in_array( siteorigin_page_setting( 'layout', 'default' ), array( 'default' ), true ) ) : ?>
+						<?php the_post_thumbnail(); ?>
+					<?php else : ?>
+						<?php the_post_thumbnail( 'siteorigin-unwind-360x238-crop', array( 'class' => 'aligncenter' ) ); ?>
+					<?php endif; ?>
 				</a>
 			<?php endif; ?>
 


### PR DESCRIPTION
![Blog_Alternate_Layout_-_Unwind](https://user-images.githubusercontent.com/789159/100521463-6bf0a100-31ac-11eb-9e8b-f471c1e767e6.jpg)

Resolve the above issue by only loading the sized featured image if the page layout in use is the default.