### PR TITLE
Removed footer text space

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -296,7 +296,7 @@ function siteorigin_unwind_footer_text() {
 		array( get_bloginfo( 'sitename' ), date( 'Y' ) ),
 		'<span>' . $text . '</span>'
 	);
-	echo wp_kses_post( $text ) . '&nbsp;';
+	echo wp_kses_post( $text );
 }
 endif;
 


### PR DESCRIPTION
@AlexGStapleton I don't know why this space was there, maybe from another theme where the function was originally written? There are several combos to test. Items to consider:

* With and without footer text.
* With and without privacy policy link.
* With and without footer attribution link.

All seems fine to me, if you could confirm, that would be best.

Cheers