### PR TITLE
Fix WooCommerce qty button styling in WCTB

### DIFF
--- a/sass/woocommerce/_product.scss
+++ b/sass/woocommerce/_product.scss
@@ -122,58 +122,6 @@
 				.woocommerce-variation-price {
 					margin-bottom: 20px;
 				}
-
-				.quantity.button-controls {
-					@include clearfix;
-					min-width: 120px;
-
-					.qty {
-						-moz-appearance: textfield;
-						border-color: $color__text-light;
-						border-radius: 0;
-						border-width: 1px;
-						color: $color__text-medium;
-						float: left;
-						height: 40px;
-						padding: 0;
-						width: 40px;
-
-						&::-webkit-inner-spin-button,
-						&::-webkit-outer-spin-button {
-							-webkit-appearance: none;
-							margin: 0;
-						}
-					}
-
-					.add,
-					.subtract {
-						background: #f9f9f9;
-						border-color: $color__text-light;
-						border-radius: 0;
-						border-width: 1px;
-						float: left;
-						height: 40px;
-						padding: 6px 10px;
-						width: 40px;
-
-						&:hover {
-							background: $color__text-medium;
-							color: #fff;
-						}
-					}
-
-					&.hidden {
-						display: none;
-					}
-
-					.subtract {
-						border-right: none;
-					}
-
-					.add {
-						border-left: none;
-					}
-				}
 			}
 
 			.group_table {
@@ -429,7 +377,12 @@
 	}
 }
 
+// Product variations.
 .variations {
+
+	td {
+		padding: 0;
+	}
 
 	select {
 		@include appearance(none);
@@ -473,5 +426,58 @@
 	tr,
 	tr:nth-child(2n+2) {
 		background: transparent;
+	}
+}
+
+// Product quantity buttons.
+.quantity.button-controls {
+	@include clearfix;
+	min-width: 120px;
+
+	.qty {
+		-moz-appearance: textfield;
+		border-color: $color__text-light;
+		border-radius: 0;
+		border-width: 1px;
+		color: $color__text-medium;
+		float: left;
+		height: 40px;
+		padding: 0;
+		width: 40px;
+
+		&::-webkit-inner-spin-button,
+		&::-webkit-outer-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+	}
+
+	.add,
+	.subtract {
+		background: #f9f9f9;
+		border-color: $color__text-light;
+		border-radius: 0;
+		border-width: 1px;
+		float: left;
+		height: 40px;
+		padding: 6px 10px;
+		width: 40px;
+
+		&:hover {
+			background: $color__text-medium;
+			color: #fff;
+		}
+	}
+
+	&.hidden {
+		display: none;
+	}
+
+	.subtract {
+		border-right: none;
+	}
+
+	.add {
+		border-left: none;
 	}
 }

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -559,45 +559,6 @@ p.demo_store {
         padding: 0; }
     .woocommerce.single-product #content div.product .entry-summary .cart .woocommerce-variation-price {
       margin-bottom: 20px; }
-    .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls {
-      min-width: 120px; }
-      .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls::after {
-        clear: both;
-        content: "";
-        display: table; }
-      .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .qty {
-        -moz-appearance: textfield;
-        border-color: #adadad;
-        border-radius: 0;
-        border-width: 1px;
-        color: #626262;
-        float: left;
-        height: 40px;
-        padding: 0;
-        width: 40px; }
-        .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .qty::-webkit-inner-spin-button, .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .qty::-webkit-outer-spin-button {
-          -webkit-appearance: none;
-          margin: 0; }
-      .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .add,
-      .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .subtract {
-        background: #f9f9f9;
-        border-color: #adadad;
-        border-radius: 0;
-        border-width: 1px;
-        float: left;
-        height: 40px;
-        padding: 6px 10px;
-        width: 40px; }
-        .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .add:hover,
-        .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .subtract:hover {
-          background: #626262;
-          color: #fff; }
-      .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls.hidden {
-        display: none; }
-      .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .subtract {
-        border-right: none; }
-      .woocommerce.single-product #content div.product .entry-summary .cart .quantity.button-controls .add {
-        border-left: none; }
   .woocommerce.single-product #content div.product .entry-summary .group_table {
     display: block;
     padding-bottom: 30px; }
@@ -758,6 +719,9 @@ p.demo_store {
       margin: 0 0 27px;
       width: 100%; } }
 
+.variations td {
+  padding: 0; }
+
 .variations select {
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -795,6 +759,46 @@ p.demo_store {
 .variations tr,
 .variations tr:nth-child(2n+2) {
   background: transparent; }
+
+.quantity.button-controls {
+  min-width: 120px; }
+  .quantity.button-controls::after {
+    clear: both;
+    content: "";
+    display: table; }
+  .quantity.button-controls .qty {
+    -moz-appearance: textfield;
+    border-color: #adadad;
+    border-radius: 0;
+    border-width: 1px;
+    color: #626262;
+    float: left;
+    height: 40px;
+    padding: 0;
+    width: 40px; }
+    .quantity.button-controls .qty::-webkit-inner-spin-button, .quantity.button-controls .qty::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0; }
+  .quantity.button-controls .add,
+  .quantity.button-controls .subtract {
+    background: #f9f9f9;
+    border-color: #adadad;
+    border-radius: 0;
+    border-width: 1px;
+    float: left;
+    height: 40px;
+    padding: 6px 10px;
+    width: 40px; }
+    .quantity.button-controls .add:hover,
+    .quantity.button-controls .subtract:hover {
+      background: #626262;
+      color: #fff; }
+  .quantity.button-controls.hidden {
+    display: none; }
+  .quantity.button-controls .subtract {
+    border-right: none; }
+  .quantity.button-controls .add {
+    border-left: none; }
 
 /*--------------------------------------------------------------
 # Checkout


### PR DESCRIPTION
<img width="405" alt="Cursor_and_WCTB__Resolve_single_product_variation_selection_·_Issue__307_·_siteorigin_siteorigin-unwind" src="https://user-images.githubusercontent.com/789159/120891315-2fdd4380-c608-11eb-8e43-92bfe73948b8.png">

Styling issue for qty buttons in WCTB. To check those changes ensure buttons are properly formatted within WCTB and outside of the WCTB on a normal page.

Issue two: