### PR TITLE
 Masonry: Maintain horizontalOrder

### DIFF
--- a/js/unwind.js
+++ b/js/unwind.js
@@ -262,7 +262,8 @@ jQuery( function( $ ) {
 		if ( $( '.blog-layout-masonry' ).length ) {
 			$( '.blog-layout-masonry' ).masonry( {
 				itemSelector: '.archive-entry',
-				columnWidth: '.archive-entry'
+				columnWidth: '.archive-entry',
+				horizontalOrder: true
 			} );
 		}
 


### PR DESCRIPTION
This PR modifies the masonry template to maintain [horizontalOrder](https://masonry.desandro.com/options.html#horizontalorder). This ensures that the posts are always output in the correct order.