### PR TITLE
Update WC Templates to 7.0.1

### DIFF
--- a/woocommerce/product-searchform.php
+++ b/woocommerce/product-searchform.php
@@ -11,12 +11,10 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
- * @package WooCommerce/Templates
- * @version 3.3.0
+ * @package WooCommerce\Templates
+ * @version 7.0.1
  */
 
-// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }


### PR DESCRIPTION
Updates outdated template.

`siteorigin-unwind/woocommerce/product-searchform.php version 3.3.0 is out of date. The core version is 7.0.1,`

No changes are required for the search form so just a version bump.
