### PR TITLE
Fix Sticky Logo Not Being Aligned

### DIFF
--- a/sass/site/header/_masthead.scss
+++ b/sass/site/header/_masthead.scss
@@ -141,7 +141,7 @@
 		}
 
 		@at-root body.sticky-bar-out #masthead .alt-logo-scroll {
-			display: block;
+			display: inline-block;
 		}
 	}
 

--- a/style.css
+++ b/style.css
@@ -1654,7 +1654,7 @@ a {
     .alt-logo-scroll {
       display: none; }
     body.sticky-bar-out #masthead .alt-logo-scroll {
-      display: block; }
+      display: inline-block; }
   #masthead #masthead-widgets {
     margin: 60px auto; }
     #masthead #masthead-widgets::after {


### PR DESCRIPTION
This PR will resolve an alignment issue with the sticky logo. This issue is only visible when the Header Design is set to something other than `Menu inline with logo`.